### PR TITLE
chore: drops support for Python 3.6, formats with Black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length=100
+max-line-length = 120

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ["3.6", "3.7", "3.8", "3.9"]
+        pythonversion: ["3.7", "3.8", "3.9"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.3.0 (2021-09-20)
+
+* Drops support for Python 3.6
+* Swaps `mock` library for builtin `unittest.mock` library
+* Formats project with `Black`
+
 ## v2.2.0 (2021-04-12)
 
 * Removed the `branch` flag and functionality as it was causing issues and inconsistencies when cloning/rebasing and branches didn't match up. This became especially prevelant when repos started changing from master to main. Now, we will retrieve the default branch from the parent repo (upstream) and rebase against that. This ensures consistency and safety

--- a/forks_sync/sync.py
+++ b/forks_sync/sync.py
@@ -9,20 +9,17 @@ from github import Github
 
 GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
 USER = Github(GITHUB_TOKEN).get_user()
-FORKS_SYNC_LOCATION = os.path.expanduser(
-    os.getenv('FORKS_SYNC_LOCATION', '~/forks-sync')
-)
+FORKS_SYNC_LOCATION = os.path.expanduser(os.getenv('FORKS_SYNC_LOCATION', '~/forks-sync'))
 LOG_PATH = os.path.join(FORKS_SYNC_LOCATION, 'logs')
 LOG_FILE = os.path.join(LOG_PATH, 'forks.log')
 LOGGER = logging.getLogger(__name__)
 TIMEOUT = 180
 
 
-class ForksSync():
+class ForksSync:
     @staticmethod
     def run():
-        """Run the Forks Sync script
-        """
+        """Run the Forks Sync script"""
         start_time = datetime.now()
 
         ForksSync._setup_logging()
@@ -31,13 +28,14 @@ class ForksSync():
         ForksSync.iterate_repos(repos)
 
         execution_time = f'Execution time: {datetime.now() - start_time}.'
-        message = f'Forks Sync complete! Your forks are now up to date with their remote default branch.\n{execution_time}'  # noqa
+        message = (
+            f'Forks Sync complete! Your forks are now up to date with their remote default branch.\n{execution_time}'
+        )
         LOGGER.info(message)
 
     @staticmethod
     def _verify_github_token():
-        """Verify that a GitHub Token is present
-        """
+        """Verify that a GitHub Token is present"""
         if not GITHUB_TOKEN:
             message = 'GITHUB_TOKEN must be present to run forks-sync.'
             LOGGER.critical(message)
@@ -45,27 +43,23 @@ class ForksSync():
 
     @staticmethod
     def _setup_logging():
-        """Setup project logging (to console and log file)
-        """
+        """Setup project logging (to console and log file)"""
         if not os.path.exists(LOG_PATH):
             os.makedirs(LOG_PATH)
         LOGGER.setLevel(logging.INFO)
         handler = logging.handlers.RotatingFileHandler(
             LOG_FILE,
             maxBytes=100000,
-            backupCount=5
+            backupCount=5,
         )
-        formatter = logging.Formatter(
-            "%(asctime)s - %(levelname)s - %(message)s"
-        )
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
         handler.setFormatter(formatter)
         LOGGER.addHandler(logging.StreamHandler())
         LOGGER.addHandler(handler)
 
     @staticmethod
     def get_forked_repos():
-        """Gets all the repos of a user and returns a list of forks
-        """
+        """Gets all the repos of a user and returns a list of forks"""
         repos = USER.get_repos()
         forked_repos = [repo for repo in repos if repo.fork and repo.owner.name == USER.name]
 
@@ -73,16 +67,16 @@ class ForksSync():
 
     @staticmethod
     def iterate_repos(repos):
-        """Iterate over each forked repo and concurrently start an update process
-        """
+        """Iterate over each forked repo and concurrently start an update process"""
         thread_list = []
         for repo in repos:
-            repo_path = os.path.join(
-                FORKS_SYNC_LOCATION, 'forks', repo.name
-            )
+            repo_path = os.path.join(FORKS_SYNC_LOCATION, 'forks', repo.name)
             fork_thread = Thread(
                 target=ForksSync.sync_forks,
-                args=(repo, repo_path,)
+                args=(
+                    repo,
+                    repo_path,
+                ),
             )
             thread_list.append(fork_thread)
             fork_thread.start()
@@ -102,20 +96,21 @@ class ForksSync():
 
     @staticmethod
     def clone_repo(repo, repo_path):
-        """Clone projects that don't exist
-        """
+        """Clone projects that don't exist"""
+        command = (
+            f'git clone --depth=1 {repo.ssh_url} {repo_path}'
+            f' && cd {repo_path}'
+            f' && git remote add upstream {repo.parent.clone_url}',
+        )
+
         try:
             subprocess.run(
-                (
-                    f'git clone --depth=1 {repo.ssh_url} {repo_path}'
-                    f' && cd {repo_path}'
-                    f' && git remote add upstream {repo.parent.clone_url}'
-                ),
+                command,
                 stdin=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 shell=True,
                 check=True,
-                timeout=TIMEOUT
+                timeout=TIMEOUT,
             )
             data = f'{repo.name} cloned!'
             LOGGER.info(data)
@@ -128,23 +123,24 @@ class ForksSync():
 
     @staticmethod
     def rebase_repo(repo, repo_path):
-        """Rebase your origin fork against the upstream default branch
-        """
+        """Rebase your origin fork against the upstream default branch"""
         branch = repo.parent.default_branch
+        command = (
+            f'cd {repo_path}'
+            f' && git checkout {branch}'
+            ' && git fetch upstream'
+            f' && git rebase upstream/{branch}'
+            ' && git push origin -f',
+        )
+
         try:
             subprocess.run(
-                (
-                    f'cd {repo_path}'
-                    f' && git checkout {branch}'
-                    f' && git fetch upstream'
-                    f' && git rebase upstream/{branch}'
-                    f' && git push origin -f'
-                ),
+                command,
                 stdin=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 shell=True,
                 check=True,
-                timeout=TIMEOUT
+                timeout=TIMEOUT,
             )
             data = f'{repo.name} rebased!'
             LOGGER.info(data)

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,13 @@ REQUIREMENTS = [
 DEV_REQUIREMENTS = [
     'coveralls == 3.*',
     'flake8',
-    'mock == 4.*',
     'pytest == 6.*',
     'pytest-cov == 2.*',
 ]
 
 setuptools.setup(
     name='forks-sync',
-    version='2.2.0',
+    version='2.3.0',
     description='Keep all your git forks up to date with the remote main branch.',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -32,12 +31,12 @@ setuptools.setup(
     ],
     install_requires=REQUIREMENTS,
     extras_require={
-        'dev': DEV_REQUIREMENTS
+        'dev': DEV_REQUIREMENTS,
     },
     entry_points={
         'console_scripts': [
-            'forks-sync=forks_sync.sync:main'
-        ]
+            'forks-sync=forks_sync.sync:main',
+        ],
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,10 +1,11 @@
-import mock
+from unittest.mock import Mock
+
 import pytest
 
 
 @pytest.fixture(scope='module')
 def mock_repo():
-    mock_repo = mock.Mock()
+    mock_repo = Mock()
     mock_repo.name = 'mock-repo'
     mock_repo.fork = True
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -7,9 +7,11 @@ def mock_repo():
     mock_repo = mock.Mock()
     mock_repo.name = 'mock-repo'
     mock_repo.fork = True
+
     return mock_repo
 
 
 @pytest.fixture(scope='module')
 def mock_repo_path():
+
     return 'test/forks/mock-repo'

--- a/test/unit/test_forks.py
+++ b/test/unit/test_forks.py
@@ -1,109 +1,121 @@
 import subprocess
+from unittest.mock import mock_open, patch
 
-import mock
 import pytest
 from forks_sync import ForksSync
 
 
-@mock.patch('forks_sync.sync.GITHUB_TOKEN', '123')
-@mock.patch('forks_sync.sync.USER.get_repos')
-@mock.patch('forks_sync.sync.USER')
-@mock.patch('forks_sync.sync.ForksSync._setup_logging')
-@mock.patch('forks_sync.sync.ForksSync._verify_github_token')
-@mock.patch('forks_sync.sync.LOGGER')
-def test_run(mock_logger, mock_verify_github_token, mock_setup_logging, mock_user, mock_get_repos):  # noqa
+@patch('forks_sync.sync.GITHUB_TOKEN', '123')
+@patch('forks_sync.sync.USER.get_repos')
+@patch('forks_sync.sync.USER')
+@patch('forks_sync.sync.ForksSync._setup_logging')
+@patch('forks_sync.sync.ForksSync._verify_github_token')
+@patch('forks_sync.sync.LOGGER')
+def test_run(mock_logger, mock_verify_github_token, mock_setup_logging, mock_user, mock_get_repos):
     ForksSync.run()
+
     mock_logger.info.assert_called_once()
     mock_verify_github_token.assert_called_once()
     mock_setup_logging.assert_called_once()
 
 
-@mock.patch('forks_sync.sync.GITHUB_TOKEN', None)
-@mock.patch('forks_sync.sync.LOGGER')
+@patch('forks_sync.sync.GITHUB_TOKEN', None)
+@patch('forks_sync.sync.LOGGER')
 def test_verify_github_token(mock_logger):
     message = 'GITHUB_TOKEN must be present to run forks-sync.'
     with pytest.raises(ValueError) as error:
         ForksSync._verify_github_token()
     mock_logger.critical.assert_called_with(message)
+
     assert message == str(error.value)
 
 
-@mock.patch('forks_sync.sync.LOG_PATH', 'test/mock-dir')
-@mock.patch('forks_sync.sync.LOG_FILE', './test/test.log')
-@mock.patch('os.makedirs')
-@mock.patch('forks_sync.sync.LOGGER')
+@patch('forks_sync.sync.LOG_PATH', 'test/mock-dir')
+@patch('forks_sync.sync.LOG_FILE', './test/test.log')
+@patch('os.makedirs')
+@patch('forks_sync.sync.LOGGER')
 def test_setup_logger(mock_logger, mock_make_dirs):
-    with mock.patch('builtins.open', mock.mock_open()):
+    with patch('builtins.open', mock_open()):
         ForksSync._setup_logging()
+
     mock_make_dirs.assert_called_once()
     mock_logger.setLevel.assert_called()
     mock_logger.addHandler.assert_called()
 
 
-@mock.patch('forks_sync.sync.USER.get_repos')
-@mock.patch('forks_sync.sync.USER')
+@patch('forks_sync.sync.USER.get_repos')
+@patch('forks_sync.sync.USER')
 def test_get_forked_repos(mock_user, mock_get_repos):
     ForksSync.get_forked_repos()
+
     mock_get_repos.assert_called_once()
 
 
-@mock.patch('forks_sync.sync.FORKS_SYNC_LOCATION', 'test')
-@mock.patch('forks_sync.sync.ForksSync.sync_forks')
+@patch('forks_sync.sync.FORKS_SYNC_LOCATION', 'test')
+@patch('forks_sync.sync.ForksSync.sync_forks')
 def test_iterate_repos_fork_true(mock_sync_forks, mock_repo):
     mock_repos = [mock_repo]
     ForksSync.iterate_repos(mock_repos)
+
     mock_sync_forks.assert_called_with(mock_repo, 'test/forks/mock-repo')
 
 
-@mock.patch('forks_sync.sync.ForksSync.rebase_repo')
-@mock.patch('forks_sync.sync.ForksSync.clone_repo')
-def test_sync_forks(mock_clone_repo, mock_rebase_repo, mock_repo, mock_repo_path):  # noqa
+@patch('forks_sync.sync.ForksSync.rebase_repo')
+@patch('forks_sync.sync.ForksSync.clone_repo')
+def test_sync_forks(mock_clone_repo, mock_rebase_repo, mock_repo, mock_repo_path):
     ForksSync.sync_forks(mock_repo, mock_repo_path)
+
     mock_clone_repo.assert_called_with(mock_repo, mock_repo_path)
     mock_rebase_repo.assert_called_with(mock_repo, mock_repo_path)
 
 
-@mock.patch('subprocess.run')
-@mock.patch('forks_sync.sync.LOGGER')
+@patch('subprocess.run')
+@patch('forks_sync.sync.LOGGER')
 def test_clone_repo(mock_logger, mock_subprocess, mock_repo, mock_repo_path):
     # TODO: Mock the subprocess better to ensure it does what is intended
     ForksSync.clone_repo(mock_repo, mock_repo_path)
+
     mock_logger.info.assert_called_once_with(mock_repo.name + ' cloned!')
 
 
-@mock.patch('forks_sync.sync.LOGGER')
-@mock.patch('subprocess.run', side_effect=subprocess.TimeoutExpired(cmd=subprocess.run, timeout=0.1))  # noqa
-def test_clone_repo_timeout_exception(mock_exception, mock_logger, mock_repo, mock_repo_path):  # noqa
+@patch('forks_sync.sync.LOGGER')
+@patch('subprocess.run', side_effect=subprocess.TimeoutExpired(cmd=subprocess.run, timeout=0.1))
+def test_clone_repo_timeout_exception(mock_exception, mock_logger, mock_repo, mock_repo_path):
     message = 'Forks Sync timed out cloning ' + mock_repo.name + '.'
     ForksSync.clone_repo(mock_repo, mock_repo_path)
+
     mock_logger.warning.assert_called_with(message)
 
 
-@mock.patch('forks_sync.sync.LOGGER')
-@mock.patch('subprocess.run', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.run))  # noqa
-def test_clone_repo_called_process_error(mock_exception, mock_logger, mock_repo, mock_repo_path):  # noqa
+@patch('forks_sync.sync.LOGGER')
+@patch('subprocess.run', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.run))
+def test_clone_repo_called_process_error(mock_exception, mock_logger, mock_repo, mock_repo_path):
     ForksSync.clone_repo(mock_repo, mock_repo_path)
+
     mock_logger.warning.assert_called_once()
 
 
-@mock.patch('subprocess.run')
-@mock.patch('forks_sync.sync.LOGGER')
+@patch('subprocess.run')
+@patch('forks_sync.sync.LOGGER')
 def test_rebase_repo(mock_logger, mock_subprocess, mock_repo, mock_repo_path):
     # TODO: Mock the subprocess better to ensure it does what is intended
     ForksSync.rebase_repo(mock_repo, mock_repo_path)
+
     mock_logger.info.assert_called_once_with(mock_repo.name + ' rebased!')
 
 
-@mock.patch('forks_sync.sync.LOGGER')
-@mock.patch('subprocess.run', side_effect=subprocess.TimeoutExpired(cmd=subprocess.run, timeout=0.1))  # noqa
-def test_rebase_repo_timeout_exception(mock_exception, mock_logger, mock_repo, mock_repo_path):  # noqa
+@patch('forks_sync.sync.LOGGER')
+@patch('subprocess.run', side_effect=subprocess.TimeoutExpired(cmd=subprocess.run, timeout=0.1))
+def test_rebase_repo_timeout_exception(mock_exception, mock_logger, mock_repo, mock_repo_path):
     message = 'Forks Sync timed out rebasing ' + mock_repo.name + '.'
     ForksSync.rebase_repo(mock_repo, mock_repo_path)
+
     mock_logger.warning.assert_called_with(message)
 
 
-@mock.patch('forks_sync.sync.LOGGER')
-@mock.patch('subprocess.run', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.run))  # noqa
-def test_rebase_repo_called_process_error(mock_exception, mock_logger, mock_repo, mock_repo_path):  # noqa
+@patch('forks_sync.sync.LOGGER')
+@patch('subprocess.run', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.run))
+def test_rebase_repo_called_process_error(mock_exception, mock_logger, mock_repo, mock_repo_path):
     ForksSync.rebase_repo(mock_repo, mock_repo_path)
+
     mock_logger.warning.assert_called_once()


### PR DESCRIPTION
* Drops support for Python 3.6
* Swaps `mock` library for builtin `unittest.mock` library
* Formats project with `Black`