### PR TITLE
chore: complete refactor to use argparse and classes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,2 @@
-[report]
-exclude_lines =
-    if __name__ == '__main__':
-    main()
-    Cli()
+[run]
+omit = forks_sync/cli.py

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Options:
     -to TIMEOUT, --timeout TIMEOUT
                             The number of seconds before a git operation times out.
     -l LOCATION, --location LOCATION
-                            The location where you want your GitHub Archive to be stored.
+                            The location where you want your forks and logs to be stored.
 ```
 
 ### Automating SSH Passphrase Prompt (Recommended)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Forks Sync
 
-Keep all your git forks up to date with the remote main branch.
+Keep all your git forks up to date with the remote default branch.
 
 [![Build Status](https://github.com/Justintime50/forks-sync/workflows/build/badge.svg)](https://github.com/Justintime50/forks-sync/actions)
 [![Coverage Status](https://coveralls.io/repos/github/Justintime50/forks-sync/badge.svg?branch=main)](https://coveralls.io/github/Justintime50/forks-sync?branch=main)

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Keep all your git forks up to date with the remote default branch.
 
 </div>
 
-If you manage more than a couple git forks, keeping them up to date with the remote default branch can be a pain. Forks Sync lets you avoid all the fuss by concurrently cloning each of your projects locally, adding the remote upstream, fetching new changes, rebasing your local default branch against the remote default branch, and `force pushing` to your origin repo's default branch - keeping all your forks up to date with the original repo.
+If you manage more than a couple git forks, keeping them up to date with their remote default branch can be a pain. Forks Sync lets you avoid all the fuss by concurrently cloning each of your projects locally, adding the remote upstream, fetching new changes, rebasing your local default branch against the remote default branch, and `force pushing` to your repo's origin default branch - keeping all your forks up to date with the original repo.
 
 By default, Forks Sync will save all your forks to `~/forks-sync` where you can also find logs for this tool.
 
-**Note:** Before proceeding, know that this tool will forcefully update the default branch of your fork to match the upstream default branch.
+**NOTE:** Before proceeding, know that this tool will forcefully update the default branch of your fork to match the upstream default branch.
 
 ## Install
 
@@ -31,15 +31,32 @@ make install
 
 ## Usage
 
+
+
+```
+Usage:
+    forks-sync --token 123...
+
+Options:
+    -h, --help            show this help message and exit
+    -t TOKEN, --token TOKEN
+                            Provide your GitHub token to authenticate with the GitHub API.
+    -f, --force           Pass this flag to force push changes to forked repos, otherwise the tool will run in "dry mode".
+    -th THREADS, --threads THREADS
+                            The number of threads to run.
+    -to TIMEOUT, --timeout TIMEOUT
+                            The number of seconds before a git operation times out.
+    -l LOCATION, --location LOCATION
+                            The location where you want your GitHub Archive to be stored.
+```
+
+### Automating SSH Passphrase Prompt (Recommended)
+
+To allow the script to run continuosly without requiring your SSH passphrase, you'll need to add your passphrase to the SSH agent. **NOTE:** Your SSH passphrase will be unloaded upon logout.
+
 ```bash
-# Setup your ssh agent to ensure the script runs continually
+# This assumes you've saved your SSH keys to the default location
 ssh-add
-
-# Pass your GitHub API key/token here:
-GITHUB_TOKEN=123... forks-sync
-
-# Optional params:
-# FORKS_SYNC_LOCATION="~/my-folder"
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ make install
 
 ## Usage
 
-
-
 ```
 Usage:
     forks-sync --token 123...

--- a/forks_sync/cli.py
+++ b/forks_sync/cli.py
@@ -1,9 +1,7 @@
 import argparse
-import os
 
 from forks_sync import ForksSync
-
-DEFAULT_LOCATION = os.path.expanduser('~/github-archive')
+from forks_sync.constants import DEFAULT_LOCATION, DEFAULT_NUM_THREADS, DEFAULT_TIMEOUT
 
 
 class ForksSyncCli:
@@ -18,18 +16,44 @@ class ForksSyncCli:
             help='Provide your GitHub token to authenticate with the GitHub API.',
         ),
         parser.add_argument(
+            '-f',
+            '--force',
+            action='store_true',
+            required=False,
+            default=False,
+            help='Pass this flag to force push changes to forked repos, otherwise the tool will run in "dry mode".',
+        ),
+        parser.add_argument(
+            '-th',
+            '--threads',
+            type=int,
+            required=False,
+            default=DEFAULT_NUM_THREADS,
+            help='The number of threads to run.',
+        ),
+        parser.add_argument(
+            '-to',
+            '--timeout',
+            type=int,
+            required=False,
+            default=DEFAULT_TIMEOUT,
+            help='The number of seconds before a git operation times out.',
+        ),
+        parser.add_argument(
             '-l',
             '--location',
             type=str,
             required=False,
             default=DEFAULT_LOCATION,
             help='The location where you want your GitHub Archive to be stored.',
-        )
+        ),
         parser.parse_args(namespace=self)
 
     def run(self):
         forks_sync = ForksSync(
             token=self.token,
+            threads=self.threads,
+            timeout=self.timeout,
             location=self.location,
         )
         forks_sync.run()

--- a/forks_sync/cli.py
+++ b/forks_sync/cli.py
@@ -54,6 +54,7 @@ class ForksSyncCli:
     def run(self):
         forks_sync = ForksSync(
             token=self.token,
+            force=self.force,
             threads=self.threads,
             timeout=self.timeout,
             location=self.location,

--- a/forks_sync/cli.py
+++ b/forks_sync/cli.py
@@ -6,7 +6,9 @@ from forks_sync.constants import DEFAULT_LOCATION, DEFAULT_NUM_THREADS, DEFAULT_
 
 class ForksSyncCli:
     def __init__(self):
-        parser = argparse.ArgumentParser(description='Keep all your git forks up to date with the remote main branch.')
+        parser = argparse.ArgumentParser(
+            description='Keep all your git forks up to date with the remote default branch.'
+        )
         parser.add_argument(
             '-t',
             '--token',

--- a/forks_sync/cli.py
+++ b/forks_sync/cli.py
@@ -47,7 +47,7 @@ class ForksSyncCli:
             type=str,
             required=False,
             default=DEFAULT_LOCATION,
-            help='The location where you want your GitHub Archive to be stored.',
+            help='The location where you want your forks and logs to be stored.',
         ),
         parser.parse_args(namespace=self)
 

--- a/forks_sync/cli.py
+++ b/forks_sync/cli.py
@@ -1,0 +1,43 @@
+import argparse
+import os
+
+from forks_sync import ForksSync
+
+DEFAULT_LOCATION = os.path.expanduser('~/github-archive')
+
+
+class ForksSyncCli:
+    def __init__(self):
+        parser = argparse.ArgumentParser(description='Keep all your git forks up to date with the remote main branch.')
+        parser.add_argument(
+            '-t',
+            '--token',
+            type=str,
+            required=True,
+            default=None,
+            help='Provide your GitHub token to authenticate with the GitHub API.',
+        ),
+        parser.add_argument(
+            '-l',
+            '--location',
+            type=str,
+            required=False,
+            default=DEFAULT_LOCATION,
+            help='The location where you want your GitHub Archive to be stored.',
+        )
+        parser.parse_args(namespace=self)
+
+    def run(self):
+        forks_sync = ForksSync(
+            token=self.token,
+            location=self.location,
+        )
+        forks_sync.run()
+
+
+def main():
+    ForksSyncCli().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/forks_sync/constants.py
+++ b/forks_sync/constants.py
@@ -1,0 +1,5 @@
+import os
+
+DEFAULT_LOCATION = os.path.expanduser('~/forks-sync')
+DEFAULT_NUM_THREADS = 10
+DEFAULT_TIMEOUT = 300

--- a/forks_sync/logger.py
+++ b/forks_sync/logger.py
@@ -1,0 +1,29 @@
+import logging
+import logging.handlers
+import os
+
+# 200kb * 5 files = 1mb of logs
+LOG_MAX_BYTES = 200000  # 200kb
+LOG_BACKUP_COUNT = 5
+
+
+class Logger:
+    @staticmethod
+    def setup_logging(logger, location):
+        """Setup project logging (to console and log file)"""
+        log_path = os.path.join(location, 'logs')
+        log_file = os.path.join(log_path, 'forks-sync.log')
+
+        if not os.path.exists(log_path):
+            os.makedirs(log_path)
+
+        logger.setLevel(logging.INFO)
+        handler = logging.handlers.RotatingFileHandler(
+            log_file,
+            maxBytes=LOG_MAX_BYTES,
+            backupCount=LOG_BACKUP_COUNT,
+        )
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(logging.StreamHandler())
+        logger.addHandler(handler)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ DEV_REQUIREMENTS = [
 setuptools.setup(
     name='forks-sync',
     version='2.3.0',
-    description='Keep all your git forks up to date with the remote main branch.',
+    description='Keep all your git forks up to date with the remote default branch.',
     long_description=long_description,
     long_description_content_type="text/markdown",
     url='http://github.com/justintime50/forks-sync',
@@ -37,7 +37,7 @@ setuptools.setup(
     },
     entry_points={
         'console_scripts': [
-            'forks-sync=forks_sync.sync:main',
+            'forks-sync=forks_sync.cli:main',
         ],
     },
     python_requires='>=3.7',

--- a/test/unit/test_logger.py
+++ b/test/unit/test_logger.py
@@ -1,0 +1,31 @@
+import os
+from unittest.mock import mock_open, patch
+
+from forks_sync.logger import Logger
+
+LOG_PATH = 'test/mock-dir'
+LOG_FILE = './test/test.log'
+
+
+@patch('os.makedirs')
+@patch('forks_sync.sync.LOGGER')
+def test_setup_logging(mock_logger, mock_make_dirs):
+    with patch('builtins.open', mock_open()):
+        Logger.setup_logging(mock_logger, LOG_PATH)
+    mock_make_dirs.assert_called_once()
+    mock_logger.setLevel.assert_called()
+    mock_logger.addHandler.assert_called()
+
+
+@patch('os.makedirs')
+@patch('forks_sync.sync.LOGGER')
+def test_setup_logging_dir_exists(mock_logger, mock_make_dirs):
+    # TODO: Mock this better so we don't need a gitignored empty folder for testing
+    if not os.path.exists('./logs'):
+        os.mkdir('logs')
+
+    with patch('builtins.open', mock_open()):
+        Logger.setup_logging(mock_logger, './')
+    mock_make_dirs.assert_not_called()
+    mock_logger.setLevel.assert_called()
+    mock_logger.addHandler.assert_called()

--- a/test/unit/test_sync.py
+++ b/test/unit/test_sync.py
@@ -1,80 +1,74 @@
 import subprocess
-from unittest.mock import mock_open, patch
+from threading import BoundedSemaphore
+from unittest.mock import patch
 
 import pytest
 
 from forks_sync import ForksSync
+from forks_sync.constants import DEFAULT_NUM_THREADS
 
 
-@patch('forks_sync.sync.GITHUB_TOKEN', '123')
-@patch('forks_sync.sync.USER.get_repos')
-@patch('forks_sync.sync.USER')
-@patch('forks_sync.sync.ForksSync._setup_logging')
-@patch('forks_sync.sync.ForksSync._verify_github_token')
+def mock_thread_limiter():
+    thread_limiter = BoundedSemaphore(DEFAULT_NUM_THREADS)
+
+    return thread_limiter
+
+
+@patch('forks_sync.sync.Github.get_user')
+@patch('forks_sync.sync.ForksSync.iterate_repos')
+@patch('forks_sync.logger.Logger.setup_logging')
 @patch('forks_sync.sync.LOGGER')
-def test_run(mock_logger, mock_verify_github_token, mock_setup_logging, mock_user, mock_get_repos):
-    ForksSync.run()
+def test_run(mock_logger, mock_setup_logging, mock_iterate_repos, mock_get_user):
+    ForksSync(
+        token='123',
+    ).run()
 
-    mock_logger.info.assert_called_once()
-    mock_verify_github_token.assert_called_once()
-    mock_setup_logging.assert_called_once()
+    mock_logger.info.assert_called()
 
 
-@patch('forks_sync.sync.GITHUB_TOKEN', None)
 @patch('forks_sync.sync.LOGGER')
-def test_verify_github_token(mock_logger):
-    message = 'GITHUB_TOKEN must be present to run forks-sync.'
+def test_initialize_project(mock_logger):
+    message = '"token" must be present to run forks-sync.'
     with pytest.raises(ValueError) as error:
-        ForksSync._verify_github_token()
-    mock_logger.critical.assert_called_with(message)
+        ForksSync(
+            token=None,
+        ).initialize_project()
 
+    mock_logger.critical.assert_called_with(message)
     assert message == str(error.value)
 
 
-@patch('forks_sync.sync.LOG_PATH', 'test/mock-dir')
-@patch('forks_sync.sync.LOG_FILE', './test/test.log')
-@patch('os.makedirs')
-@patch('forks_sync.sync.LOGGER')
-def test_setup_logger(mock_logger, mock_make_dirs):
-    with patch('builtins.open', mock_open()):
-        ForksSync._setup_logging()
-
-    mock_make_dirs.assert_called_once()
-    mock_logger.setLevel.assert_called()
-    mock_logger.addHandler.assert_called()
-
-
-@patch('forks_sync.sync.USER.get_repos')
-@patch('forks_sync.sync.USER')
-def test_get_forked_repos(mock_user, mock_get_repos):
-    ForksSync.get_forked_repos()
-
-    mock_get_repos.assert_called_once()
-
-
-@patch('forks_sync.sync.FORKS_SYNC_LOCATION', 'test')
 @patch('forks_sync.sync.ForksSync.sync_forks')
-def test_iterate_repos_fork_true(mock_sync_forks, mock_repo):
+def test_iterate_repos(mock_sync_forks, mock_repo):
     mock_repos = [mock_repo]
-    ForksSync.iterate_repos(mock_repos)
+    ForksSync(
+        token='123',
+        location='test',
+    ).iterate_repos(mock_repos)
 
-    mock_sync_forks.assert_called_with(mock_repo, 'test/forks/mock-repo')
+    mock_sync_forks.assert_called()
 
 
 @patch('forks_sync.sync.ForksSync.rebase_repo')
 @patch('forks_sync.sync.ForksSync.clone_repo')
 def test_sync_forks(mock_clone_repo, mock_rebase_repo, mock_repo, mock_repo_path):
-    ForksSync.sync_forks(mock_repo, mock_repo_path)
+    ForksSync(
+        token='123',
+        force=True,
+    ).sync_forks(mock_thread_limiter(), mock_repo, mock_repo_path)
 
-    mock_clone_repo.assert_called_with(mock_repo, mock_repo_path)
-    mock_rebase_repo.assert_called_with(mock_repo, mock_repo_path)
+    mock_clone_repo.assert_called()
+    mock_rebase_repo.assert_called()
 
 
 @patch('subprocess.run')
 @patch('forks_sync.sync.LOGGER')
 def test_clone_repo(mock_logger, mock_subprocess, mock_repo, mock_repo_path):
     # TODO: Mock the subprocess better to ensure it does what is intended
-    ForksSync.clone_repo(mock_repo, mock_repo_path)
+    ForksSync(
+        token='123',
+        force=True,
+    ).clone_repo(mock_thread_limiter(), mock_repo, mock_repo_path)
 
     mock_logger.info.assert_called_once_with(mock_repo.name + ' cloned!')
 
@@ -83,7 +77,10 @@ def test_clone_repo(mock_logger, mock_subprocess, mock_repo, mock_repo_path):
 @patch('subprocess.run', side_effect=subprocess.TimeoutExpired(cmd=subprocess.run, timeout=0.1))
 def test_clone_repo_timeout_exception(mock_exception, mock_logger, mock_repo, mock_repo_path):
     message = 'Forks Sync timed out cloning ' + mock_repo.name + '.'
-    ForksSync.clone_repo(mock_repo, mock_repo_path)
+    ForksSync(
+        token='123',
+        force=True,
+    ).clone_repo(mock_thread_limiter(), mock_repo, mock_repo_path)
 
     mock_logger.warning.assert_called_with(message)
 
@@ -91,7 +88,10 @@ def test_clone_repo_timeout_exception(mock_exception, mock_logger, mock_repo, mo
 @patch('forks_sync.sync.LOGGER')
 @patch('subprocess.run', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.run))
 def test_clone_repo_called_process_error(mock_exception, mock_logger, mock_repo, mock_repo_path):
-    ForksSync.clone_repo(mock_repo, mock_repo_path)
+    ForksSync(
+        token='123',
+        force=True,
+    ).clone_repo(mock_thread_limiter(), mock_repo, mock_repo_path)
 
     mock_logger.warning.assert_called_once()
 
@@ -100,7 +100,10 @@ def test_clone_repo_called_process_error(mock_exception, mock_logger, mock_repo,
 @patch('forks_sync.sync.LOGGER')
 def test_rebase_repo(mock_logger, mock_subprocess, mock_repo, mock_repo_path):
     # TODO: Mock the subprocess better to ensure it does what is intended
-    ForksSync.rebase_repo(mock_repo, mock_repo_path)
+    ForksSync(
+        token='123',
+        force=True,
+    ).rebase_repo(mock_thread_limiter(), mock_repo, mock_repo_path)
 
     mock_logger.info.assert_called_once_with(mock_repo.name + ' rebased!')
 
@@ -109,7 +112,10 @@ def test_rebase_repo(mock_logger, mock_subprocess, mock_repo, mock_repo_path):
 @patch('subprocess.run', side_effect=subprocess.TimeoutExpired(cmd=subprocess.run, timeout=0.1))
 def test_rebase_repo_timeout_exception(mock_exception, mock_logger, mock_repo, mock_repo_path):
     message = 'Forks Sync timed out rebasing ' + mock_repo.name + '.'
-    ForksSync.rebase_repo(mock_repo, mock_repo_path)
+    ForksSync(
+        token='123',
+        force=True,
+    ).rebase_repo(mock_thread_limiter(), mock_repo, mock_repo_path)
 
     mock_logger.warning.assert_called_with(message)
 
@@ -117,6 +123,9 @@ def test_rebase_repo_timeout_exception(mock_exception, mock_logger, mock_repo, m
 @patch('forks_sync.sync.LOGGER')
 @patch('subprocess.run', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.run))
 def test_rebase_repo_called_process_error(mock_exception, mock_logger, mock_repo, mock_repo_path):
-    ForksSync.rebase_repo(mock_repo, mock_repo_path)
+    ForksSync(
+        token='123',
+        force=True,
+    ).rebase_repo(mock_thread_limiter(), mock_repo, mock_repo_path)
 
     mock_logger.warning.assert_called_once()


### PR DESCRIPTION
* Refactors the entire app to use CLI arguments instead of environment variables
* Added a `--force` flag to ensure users don't accidentally blow away their default branches unless they explicitly wanted to. Without passing this flag, the tool will run in "dry mode"
* Now restricts the tool to run with 10 threads by default
* Added additional logging